### PR TITLE
{examples, templates, admin}: icon related improvements for infinity scrolling

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -667,6 +667,8 @@ func (ad *admin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		SellIcon            icon.IconType
 		InventoryIcon       icon.IconType
 		DashboardIcon       icon.IconType
+		LockIcon            icon.IconType
+		EmailIcon           icon.IconType
 	}{
 		Layout:              ad.layout,
 		Pages:               ad.pages,
@@ -687,6 +689,8 @@ func (ad *admin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		SellIcon:            icon.Sell,
 		InventoryIcon:       icon.Inventory,
 		DashboardIcon:       icon.Dashboard,
+		LockIcon:            icon.Lock,
+		EmailIcon:           icon.Email,
 	}
 
 	if err := jsxTemplate.Execute(&jsxWriter, jsxData); err != nil {

--- a/examples/infinity-scrolling/main.go
+++ b/examples/infinity-scrolling/main.go
@@ -13,7 +13,7 @@ func NewInfinityListPage() (admin.Pager, error) {
 	return admin.NewIInfinityListPage(admin.IInfinityListPageConfig{
 		PageConfig: admin.PageConfig{
 			Icon: icon.Icon{
-				Type: icon.Empty,
+				Type: icon.Lock,
 			},
 			IsDefault: true,
 			ID:        "Home",

--- a/examples/infinity-scrolling/main.go
+++ b/examples/infinity-scrolling/main.go
@@ -13,7 +13,7 @@ func NewInfinityListPage() (admin.Pager, error) {
 	return admin.NewIInfinityListPage(admin.IInfinityListPageConfig{
 		PageConfig: admin.PageConfig{
 			Icon: icon.Icon{
-				Type: icon.Lock,
+				Type: icon.Empty,
 			},
 			IsDefault: true,
 			ID:        "Home",

--- a/templates/materialUI.tsx
+++ b/templates/materialUI.tsx
@@ -1909,7 +1909,6 @@ function [[ .ID ]]InfinityList({ handleSetAppState }) {
             alignItems: 'center',
           }}
         >
-              <EmailIcon />
           [[ if gt .Icon.Type -1 ]]
           <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}></Avatar>
           [[ end ]]

--- a/templates/materialUI.tsx
+++ b/templates/materialUI.tsx
@@ -1909,15 +1909,9 @@ function [[ .ID ]]InfinityList({ handleSetAppState }) {
             alignItems: 'center',
           }}
         >
-          [[ if gt .Icon.Type -1 ]]
-          <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
-            [[ if eq .Icon.Type 7 ]]
-              <LockOutlinedIcon />
-            [[ end ]]
-            [[ if eq .Icon.Type 8 ]]
               <EmailIcon />
-            [[ end ]]
-          </Avatar>
+          [[ if gt .Icon.Type -1 ]]
+          <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}></Avatar>
           [[ end ]]
           <Typography component="h1" variant="h5">
             [[ .Form.Title ]]


### PR DESCRIPTION
#### Details
- `examples/infinity-scrolling`: sets default empty icon.
- `templates`: removes test icon component.
- `admin`: wires lock and email icons.
- `templates`: removes unused icons.