### PR TITLE
{templates,admin}: adds initial autocomplete component implementation

### DIFF
--- a/admin.go
+++ b/admin.go
@@ -586,6 +586,7 @@ func (ad *admin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				"inputMulti":        InputMulti,
 				"inputCheckbox":     InputCheckbox,
 				"inputSelect":       InputSelect,
+				"inputText":         InputText,
 				"inputAutocomplete": InputAutocomplete,
 			},
 		}

--- a/admin.go
+++ b/admin.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"reflect"
+	"strconv"
 	textTemplate "text/template"
 
 	"github.com/evanw/esbuild/pkg/api"
@@ -629,6 +630,17 @@ func (ad *admin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return template.JS(d)
 	}
 
+	toString := func(value interface{}) string {
+		switch v := value.(type) {
+		case string:
+			return v
+		case uint:
+			return strconv.Itoa(int(v))
+		default:
+			return ""
+		}
+	}
+
 	jsxTemplate, err := newTemplate("JSX").Funcs(textTemplate.FuncMap{
 		"IsNotNil":         isNotNil,
 		"Wrap":             wrap,
@@ -640,6 +652,7 @@ func (ad *admin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		"WrapUploadPage":   wrapUploadPage,
 		"WrapComponent":    wrapComponent,
 		"Marshal":          marshal,
+		"ToString":         toString,
 	}).Parse(ad.jsxTemplateText)
 	if err != nil {
 		log.Printf("failed to parse TSX template: %v", err)

--- a/admin.go
+++ b/admin.go
@@ -46,6 +46,7 @@ const (
 	InputMulti
 	InputCheckbox
 	InputSelect
+	InputAutocomplete
 )
 
 type PageType uint
@@ -581,10 +582,11 @@ func (ad *admin) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			"page":   page,
 			"pages":  pages,
 			"inputTypes": map[string]interface{}{
-				"inputCents":    InputCents,
-				"inputMulti":    InputMulti,
-				"inputCheckbox": InputCheckbox,
-				"inputSelect":   InputSelect,
+				"inputCents":        InputCents,
+				"inputMulti":        InputMulti,
+				"inputCheckbox":     InputCheckbox,
+				"inputSelect":       InputSelect,
+				"inputAutocomplete": InputAutocomplete,
 			},
 		}
 	}

--- a/templates/materialUI.tsx
+++ b/templates/materialUI.tsx
@@ -1919,7 +1919,7 @@ function [[ .ID ]]InfinityList({ handleSetAppState }) {
           </Typography>
           <Box component="form" onSubmit={handle[[ .Form.ID]]Submit} sx={{ mt: 1 }}>
               [[ range $field := .Form.Fields ]]
-            	  [[ if eq $field.Type $.inputTextType ]]
+                [[ if eq $field.Type $inputTextType ]]
                     [[ template "TextField" (Wrap $field.ID $field.Label $field.IsRequired $field.Value $field.FullWidth $field.IsMultiline $field.NumberOfRows) ]]
             	  [[ end ]]
             	[[ end ]]

--- a/templates/materialUI.tsx
+++ b/templates/materialUI.tsx
@@ -1829,6 +1829,8 @@ function [[ .ID ]]Upload({ appState, handleClearAppState, handleSetAppState }) {
 [[end]]
 
 [[define "InfinityList"]]
+[[ $inputAutocompleteType := .inputTypes.inputAutocomplete ]]
+[[ $inputTextType := .inputTypes.inputText ]]
 [[ with .page ]]
 function [[ .ID ]]InfinityList({ handleSetAppState }) {
   const history = useHistory();
@@ -1917,10 +1919,7 @@ function [[ .ID ]]InfinityList({ handleSetAppState }) {
           </Typography>
           <Box component="form" onSubmit={handle[[ .Form.ID]]Submit} sx={{ mt: 1 }}>
               [[ range $field := .Form.Fields ]]
-            	  [[ if eq $field.Type 0 ]]
-                    [[ template "PasswordField" (Wrap $field.ID $field.Label $field.IsRequired $field.Value $field.FullWidth $field.IsMultiline $field.NumberOfRows) ]]
-            	  [[ end ]]
-            	  [[ if eq $field.Type 1 ]]
+            	  [[ if eq $field.Type $.inputTextType ]]
                     [[ template "TextField" (Wrap $field.ID $field.Label $field.IsRequired $field.Value $field.FullWidth $field.IsMultiline $field.NumberOfRows) ]]
             	  [[ end ]]
             	[[ end ]]


### PR DESCRIPTION
#### Details

- `templates`: wiring input text type.
- `admin`: adds ToString template helper function.
- `templates`: wires autocomplete and text input types to infinity list component.
- `admin`: wires inputText to template.
- `admin`: wires InputAutocomplete type.